### PR TITLE
Bug buffer corrupted during send under load

### DIFF
--- a/src/client.hpp
+++ b/src/client.hpp
@@ -106,9 +106,6 @@ namespace drachtio {
         string m_strRemoteAddress;
         unsigned int m_nRemotePort;
 
-        string m_msgResponse;
-        string m_msgToSend;
-
         time_t m_tConnect ;
     };
 


### PR DESCRIPTION
In the client code, which talks using the wire protocol to the Node client, the Buffer is not maintained for the life of the async_send.

If packets come in to the Client too fast then the object's copy of the buffer is overwritten and if this is done before the async)_send completes then this corrupts the data.

This is overcome by using a auto_ptr to encapsulate a std::string which is maintained for the life of the send by passing it into the lambda function of the async_send

