### PR TITLE
ci: bump workflow actions to latest majors

### DIFF
--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -14,7 +14,7 @@ jobs:
     name: Clang static analysis
     runs-on: ubuntu-latest
     steps:
-       - uses: actions/checkout@v2
+       - uses: actions/checkout@v6
          with:
           submodules: recursive
        - run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -7,7 +7,7 @@ jobs:
   scan-latest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: build dependencies

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -12,7 +12,7 @@ jobs:
     name: Cppcheck Static Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
       - run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,7 +17,7 @@ jobs:
       SONAR_SERVER_URL: "https://sonarcloud.io"
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
           submodules: recursive
@@ -26,7 +26,7 @@ jobs:
         with:
           java-version: 11
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar


### PR DESCRIPTION
Bumps pinned GitHub Action versions in this repo's babblevoice-specific CI workflows to the current latest majors. Upgrade-only — only version tokens change.

**Bumps:**
- `actions/checkout` v2 → v6  (`.github/workflows/clang-analyzer.yml`)
- `actions/checkout` v2 → v6  (`.github/workflows/codeql-analysis.yml`)
- `actions/checkout` v2 → v6  (`.github/workflows/coverity-scan.yml`)
- `actions/checkout` v2 → v6  (`.github/workflows/cppcheck.yml`)
- `actions/checkout` v2 → v6  (`.github/workflows/sonarcloud.yml`)
- `actions/cache` v1 → v5  (`.github/workflows/sonarcloud.yml`)

_Scope note:_ `ci.yml` is left untouched because it is maintained upstream (drachtio/drachtio-server). The five workflows here are active only in this fork (upstream keeps them `.disabled`), so they're bumped. This repo has a Dockerfile, which is why its CI was included in the org-wide action-version pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
